### PR TITLE
Feat: Implement motoko docs retrieval

### DIFF
--- a/MCP_Server/mcp_server.py
+++ b/MCP_Server/mcp_server.py
@@ -24,8 +24,8 @@ except ImportError:
 # Load environment variables
 load_dotenv()
 
-# ChromaDB Setup - using relative path from API directory
-CHROMA_DIR = "chromadb_data"
+# ChromaDB Setup - always use project root directory
+CHROMA_DIR = os.path.join(os.getcwd(), "chromadb_data")
 chroma_client = chromadb.PersistentClient(path=CHROMA_DIR)
 embedding_fn = SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A Retrieval-Augmented Generation (RAG) pipeline for Motoko code search and code generation, powered by ChromaDB, local embeddings, and Google Gemini.
 
-**Project Demo (National Round)**: https://app.screencastify.com/watch/fGhZUe1zzkabRKVxm1wj
+**Project Demo (National Round)**: <https://app.screencastify.com/watch/fGhZUe1zzkabRKVxm1wj>
 
 ## RAG Pipeline
 
 <img width="1410" height="926" alt="Untitled-2025-07-18-1340" src="https://github.com/user-attachments/assets/19c42a00-8b9f-44d7-8ea1-ebde2861f4d0" />
 
-
 ## Features
+
 - Ingests and indexes all Motoko code samples from the `motoko_code_samples/` directory
 - Generates vector embeddings using a local SentenceTransformer model (`all-MiniLM-L6-v2`)
 - Stores and retrieves code samples and metadata with ChromaDB
@@ -19,6 +19,7 @@ A Retrieval-Augmented Generation (RAG) pipeline for Motoko code search and code 
 - MCP (Model Context Protocol) server for Cursor/VS Code integration (supports both process and HTTP modes)
 
 ## Requirements
+
 - Python 3.11+
 - [ChromaDB](https://www.trychroma.com/)
 - [sentence-transformers](https://www.sbert.net/)
@@ -27,6 +28,7 @@ A Retrieval-Augmented Generation (RAG) pipeline for Motoko code search and code 
 - Google Gemini API key (set `GEMINI_API_KEY` in a `.env` file)
 
 ## Setup
+
 ```bash
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
@@ -37,20 +39,48 @@ echo GEMINI_API_KEY=your-gemini-key > .env
 
 ## Quick Start
 
-### 1. Fetch Motoko Project Samples
+**IMPORTANT**: All commands must be run from the project root directory to ensure correct ChromaDB access. The system uses a single ChromaDB instance located at `chromadb_data/` in the project root.
+
+### 1. Fetch Motoko Data Sources
+
+**Important**: Run these steps in the following order to populate the ChromaDB with all necessary data.
+
+#### A. Clone Official Motoko Documentation
+
+```bash
+python clone_motoko_docs.py
+```
+
+#### B. Clone Motoko Project Samples
+
 Run the following script to automatically clone a large set of Motoko project samples into the `motoko_code_samples/` directory:
+
 ```bash
 python clone_motoko_repos.py
 ```
+
 This will download many Motoko repositories and add them to `.gitignore` automatically.
 
-### 2. Ingest Motoko Code Samples
+### 2. Ingest Data into ChromaDB
+
+**Important**: Run these ingestion scripts in order after completing step 1. All scripts must be run from the project root directory.
+
+#### A. Ingest Motoko Documentation (if available)
+
+```bash
+python ingest/motoko_docs_ingester.py
+```
+
+#### B. Ingest Motoko Code Samples
+
 This will index all `.mo` and `mops.toml` files in `motoko_code_samples/` and store their embeddings and metadata in ChromaDB.
+
 ```bash
 python ingest/motoko_samples_ingester.py
 ```
 
-### 2. Start the API System
+### 3. Start the API System
+
 ```bash
 # Terminal 1: Authentication server (port 8001)
 set PYTHONPATH=.
@@ -65,7 +95,8 @@ set PYTHONPATH=.
 python -m uvicorn API.mcp_api_server:app --reload --port 9000
 ```
 
-### 3. Test the System
+### 4. Test the System
+
 ```bash
 # Run the example client
 python API/client_example.py
@@ -75,6 +106,7 @@ python rag/inference_gemini.py
 ```
 
 ## Project Structure
+
 ```
 ICP_Coder/
 ├── API/                          # Complete API system
@@ -100,6 +132,7 @@ ICP_Coder/
 ## API Endpoints
 
 ### Authentication Server (Port 8001)
+
 - `POST /register` - Register a new user
 - `POST /login` - Login user
 - `POST /api-keys` - Create API key (requires authentication)
@@ -107,11 +140,14 @@ ICP_Coder/
 - `DELETE /api-keys/{id}` - Revoke API key (requires authentication)
 
 ### RAG API Server (Port 8000)
+
 - `POST /v1/chat/completions` - Generate Motoko code (requires API key)
 
 ### MCP HTTP Server (Port 9000)
+
 - `POST /v1/mcp/context` - Retrieve relevant Motoko code context for RAG (requires API key)
   - **Request body:**
+
     ```json
     {
       "query": "How do I write a counter canister in Motoko?",
@@ -119,17 +155,21 @@ ICP_Coder/
       "max_results": 5
     }
     ```
+
   - **Response:** JSON with context snippets, metadata, and status.
 
 ## Integration with Cursor/VS Code
 
 ### As OpenAI-Compatible Endpoint
+
 1. In Cursor/VS Code, go to your LLM extension settings
 2. Set the "OpenAI Base URL" to: `http://localhost:8000/v1/chat/completions`
 3. Set the API key to your generated API key
 
 ### As MCP HTTP Server
+
 Add to your MCP config (e.g., `mcp.config.json`):
+
 ```json
 {
   "inputs": [
@@ -156,17 +196,20 @@ Add to your MCP config (e.g., `mcp.config.json`):
   }
 }
 ```
+
 - This will prompt you for your API key and send it with every context request.
 
 ## Usage Examples
 
 ### Direct RAG Inference
+
 ```bash
 python rag/inference_gemini.py
 # Enter your Motoko question when prompted
 ```
 
 ### API Usage
+
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -179,6 +222,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 ```
 
 ### MCP HTTP Usage
+
 ```bash
 curl -X POST http://localhost:9000/v1/mcp/context \
   -H "Content-Type: application/json" \
@@ -192,6 +236,7 @@ curl -X POST http://localhost:9000/v1/mcp/context \
 ## Environment Variables
 
 Create a `.env` file in your project root:
+
 ```env
 # Required: Google Gemini API key for the RAG functionality
 GEMINI_API_KEY=your-gemini-api-key-here

--- a/clone_motoko_docs.py
+++ b/clone_motoko_docs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Configuration
+DOC_REPO_URL = "https://github.com/dfinity/motoko.git"
+TEMP_CLONE_DIR = "temp_motoko_clone"
+TARGET_DIR = "motoko_official_docs"
+DOC_SOURCE_PATH = "doc/md"
+
+def run_command(cmd, cwd=None):
+    """Run a shell command and return success status."""
+    try:
+        result = subprocess.run(cmd, shell=True, cwd=cwd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"Command failed: {cmd}")
+            print(f"Error: {result.stderr}")
+            return False
+        return True
+    except Exception as e:
+        print(f"Command execution failed: {e}")
+        return False
+
+def count_doc_files(directory):
+    """Count markdown files in directory."""
+    if not os.path.exists(directory):
+        return 0
+    
+    count = 0
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            if file.endswith(('.md', '.mdx')):
+                count += 1
+    return count
+
+def main():
+    print("Cloning Motoko Official Documentation")
+    print("=" * 52)
+    
+    # Clean up existing directories
+    if os.path.exists(TEMP_CLONE_DIR):
+        print(f"Removing existing temp directory: {TEMP_CLONE_DIR}")
+        shutil.rmtree(TEMP_CLONE_DIR)
+    
+    if os.path.exists(TARGET_DIR):
+        print(f"Removing existing docs directory: {TARGET_DIR}")
+        shutil.rmtree(TARGET_DIR)
+    
+    # Clone the repository
+    print("Cloning Motoko repository...")
+    clone_cmd = f"git clone --depth 1 {DOC_REPO_URL} {TEMP_CLONE_DIR}"
+    if not run_command(clone_cmd):
+        print("Failed to clone repository")
+        return 1
+    
+    print("Repository cloned successfully")
+    
+    # Check if documentation path exists
+    source_doc_path = os.path.join(TEMP_CLONE_DIR, DOC_SOURCE_PATH)
+    if not os.path.exists(source_doc_path):
+        print(f"Documentation path not found: {source_doc_path}")
+        shutil.rmtree(TEMP_CLONE_DIR, ignore_errors=True)
+        return 1
+    
+    # Copy documentation to target directory
+    print(f"Copying documentation from {source_doc_path} to {TARGET_DIR}")
+    try:
+        shutil.copytree(source_doc_path, TARGET_DIR)
+    except Exception as e:
+        print(f"Failed to copy documentation: {e}")
+        shutil.rmtree(TEMP_CLONE_DIR, ignore_errors=True)
+        return 1
+    
+    # Remove the old directory if it exists
+    old_dir = os.path.join(TARGET_DIR, "old")
+    if os.path.exists(old_dir):
+        print(f"Removing old documentation directory: {old_dir}")
+        shutil.rmtree(old_dir)
+        print("Old directory removed successfully")
+    
+    # Count documentation files
+    doc_count = count_doc_files(TARGET_DIR)
+    print(f"Successfully copied {doc_count} documentation files to {TARGET_DIR}")
+    
+    # Clean up temp directory
+    print(f"Cleaning up temp directory: {TEMP_CLONE_DIR}")
+    try:
+        shutil.rmtree(TEMP_CLONE_DIR)
+        if not os.path.exists(TEMP_CLONE_DIR):
+            print("Temp directory cleaned up successfully")
+        else:
+            print("Warning: Failed to remove temp directory")
+    except Exception as e:
+        print(f"Warning: Failed to remove temp directory: {e}")
+    
+    print("\nDocumentation cloning completed successfully!")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ingest/motoko_docs_ingester.py
+++ b/ingest/motoko_docs_ingester.py
@@ -1,0 +1,360 @@
+import os
+import re
+from typing import List, Dict, Tuple
+from sentence_transformers import SentenceTransformer
+import chromadb
+from chromadb.config import Settings
+from tqdm import tqdm
+
+# Directory containing documentation files
+DOCS_DIR = "motoko_official_docs"
+
+# Load the local embedding model once
+model = SentenceTransformer('all-MiniLM-L6-v2')
+
+def get_embedding(text: str) -> list:
+    """Generate embedding for given text."""
+    return model.encode(text).tolist()
+
+def extract_frontmatter(content: str) -> Tuple[Dict, str]:
+    """Extract YAML frontmatter and return metadata and content."""
+    frontmatter = {}
+    if content.startswith('---'):
+        try:
+            parts = content.split('---', 2)
+            if len(parts) >= 3:
+                frontmatter_text = parts[1].strip()
+                content = parts[2].strip()
+                # Simple YAML parsing for common fields
+                for line in frontmatter_text.split('\n'):
+                    if ':' in line:
+                        key, value = line.split(':', 1)
+                        key = key.strip()
+                        value = value.strip().strip('"\'')
+                        if key == 'sidebar_position':
+                            try:
+                                frontmatter[key] = int(value)
+                            except:
+                                frontmatter[key] = value
+                        else:
+                            frontmatter[key] = value
+        except:
+            pass
+    return frontmatter, content
+
+def parse_headers(content: str) -> List[Dict]:
+    """Parse markdown headers and return hierarchy information."""
+    headers = []
+    lines = content.split('\n')
+    
+    for i, line in enumerate(lines):
+        if line.strip().startswith('#'):
+            level = len(line) - len(line.lstrip('#'))
+            if level <= 4:  # Only consider up to h4
+                title = line.strip('#').strip()
+                headers.append({
+                    'level': level,
+                    'title': title,
+                    'line_number': i
+                })
+    return headers
+
+def get_parent_context(headers: List[Dict], current_index: int) -> str:
+    """Get parent section titles for context."""
+    if current_index == 0:
+        return ""
+    
+    current_level = headers[current_index]['level']
+    parents = []
+    
+    # Look backwards for parent headers
+    for i in range(current_index - 1, -1, -1):
+        if headers[i]['level'] < current_level:
+            parents.insert(0, headers[i]['title'])
+            current_level = headers[i]['level']
+            if current_level == 1:  # Stop at h1
+                break
+    
+    return " > ".join(parents) if parents else ""
+
+def chunk_content(content: str, headers: List[Dict], file_path: str, frontmatter: Dict) -> List[Dict]:
+    """Chunk content based on headers while preserving context."""
+    chunks = []
+    lines = content.split('\n')
+    
+    if not headers:
+        # No headers found, treat as single chunk
+        chunk_content = content.strip()
+        if chunk_content:
+            chunks.append({
+                'content': chunk_content,
+                'title': os.path.basename(file_path),
+                'parent_context': '',
+                'section_type': 'document',
+                'headers': []
+            })
+        return chunks
+    
+    for i, header in enumerate(headers):
+        start_line = header['line_number']
+        
+        # Find end line (next header of same or higher level)
+        end_line = len(lines)
+        for j in range(i + 1, len(headers)):
+            if headers[j]['level'] <= header['level']:
+                end_line = headers[j]['line_number']
+                break
+        
+        # Extract section content
+        section_lines = lines[start_line:end_line]
+        section_content = '\n'.join(section_lines).strip()
+        
+        if not section_content or len(section_content) < 50:
+            continue
+        
+        # Get parent context
+        parent_context = get_parent_context(headers, i)
+        
+        # Determine section type based on content
+        section_type = classify_section(section_content)
+        
+        # Split large sections if needed
+        if len(section_content) > 2000:  # Roughly 400-500 tokens
+            sub_chunks = split_large_section(section_content, header['title'], parent_context, section_type)
+            chunks.extend(sub_chunks)
+        else:
+            chunks.append({
+                'content': section_content,
+                'title': header['title'],
+                'parent_context': parent_context,
+                'section_type': section_type,
+                'headers': [h['title'] for h in headers[max(0, i-2):i+3]]  # Context headers
+            })
+    
+    return chunks
+
+def classify_section(content: str) -> str:
+    """Classify section type based on content patterns."""
+    content_lower = content.lower()
+    
+    if '```motoko' in content or 'func ' in content:
+        return 'api_reference'
+    elif 'example' in content_lower or 'tutorial' in content_lower:
+        return 'tutorial'
+    elif 'install' in content_lower or 'setup' in content_lower:
+        return 'setup'
+    elif 'error' in content_lower or 'warning' in content_lower:
+        return 'troubleshooting'
+    elif re.search(r'function\s+`\w+`', content):
+        return 'api_reference'
+    else:
+        return 'documentation'
+
+def split_large_section(content: str, title: str, parent_context: str, section_type: str) -> List[Dict]:
+    """Split large sections into smaller chunks while preserving meaning."""
+    chunks = []
+    
+    # Try to split on subheadings first
+    subsection_pattern = r'\n(#{3,6}[^\n]+)\n'
+    parts = re.split(subsection_pattern, content)
+    
+    if len(parts) > 1:
+        # Has subsections
+        current_chunk = parts[0]  # Content before first subsection
+        
+        for i in range(1, len(parts), 2):
+            if i + 1 < len(parts):
+                subsection_title = parts[i].strip('#').strip()
+                subsection_content = parts[i + 1]
+                
+                chunk_content = f"{parts[i]}\n{subsection_content}"
+                if len(current_chunk.strip()) > 0:
+                    chunk_content = current_chunk + "\n" + chunk_content
+                
+                if len(chunk_content) > 2500:  # Still too large
+                    # Split by paragraphs
+                    para_chunks = split_by_paragraphs(chunk_content, f"{title} - {subsection_title}", parent_context, section_type)
+                    chunks.extend(para_chunks)
+                else:
+                    chunks.append({
+                        'content': chunk_content.strip(),
+                        'title': f"{title} - {subsection_title}",
+                        'parent_context': parent_context,
+                        'section_type': section_type,
+                        'headers': []
+                    })
+                current_chunk = ""
+    else:
+        # No subsections, split by paragraphs
+        chunks = split_by_paragraphs(content, title, parent_context, section_type)
+    
+    return chunks
+
+def split_by_paragraphs(content: str, title: str, parent_context: str, section_type: str) -> List[Dict]:
+    """Split content by paragraphs when no other structure is available."""
+    chunks = []
+    paragraphs = content.split('\n\n')
+    current_chunk = ""
+    
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        
+        # Check if adding this paragraph would exceed limit
+        if len(current_chunk + para) > 1500 and current_chunk:
+            chunks.append({
+                'content': current_chunk.strip(),
+                'title': title,
+                'parent_context': parent_context,
+                'section_type': section_type,
+                'headers': []
+            })
+            current_chunk = para
+        else:
+            current_chunk += ("\n\n" if current_chunk else "") + para
+    
+    # Add remaining content
+    if current_chunk.strip():
+        chunks.append({
+            'content': current_chunk.strip(),
+            'title': title,
+            'parent_context': parent_context,
+            'section_type': section_type,
+            'headers': []
+        })
+    
+    return chunks
+
+def get_file_metadata(file_path: str, base_dir: str, frontmatter: Dict) -> Dict:
+    """Extract metadata from file path and frontmatter."""
+    rel_path = os.path.relpath(file_path, base_dir)
+    parts = rel_path.split(os.sep)
+    
+    metadata = {
+        "source_file": rel_path,
+        "filename": os.path.basename(file_path),
+        "directory": "/".join(parts[:-1]) if len(parts) > 1 else "",
+        "file_type": "documentation",
+        "content_type": "motoko_docs"
+    }
+    
+    # Add frontmatter data
+    metadata.update(frontmatter)
+    
+    # Infer document category from path
+    if "base/" in rel_path:
+        metadata["doc_category"] = "base_library"
+    elif "fundamentals/" in rel_path:
+        metadata["doc_category"] = "fundamentals"
+    elif "examples/" in rel_path:
+        metadata["doc_category"] = "examples"
+    elif "reference/" in rel_path:
+        metadata["doc_category"] = "reference"
+    elif rel_path.endswith("language-manual.md"):
+        metadata["doc_category"] = "language_reference"
+    else:
+        metadata["doc_category"] = "general"
+    
+    return metadata
+
+def find_doc_files(docs_dir: str) -> List[str]:
+    """Find all markdown documentation files."""
+    doc_files = []
+    for root, _, files in os.walk(docs_dir):
+        for file in files:
+            if file.endswith(('.md', '.mdx')):
+                file_path = os.path.join(root, file)
+                doc_files.append(file_path)
+    return doc_files
+
+def main():
+    """Main ingestion function."""
+    chroma_dir = os.path.join(os.getcwd(), "chromadb_data")
+    chroma_client = chromadb.PersistentClient(path=chroma_dir)
+    
+    # Create or get collection for documentation
+    collection = chroma_client.get_or_create_collection("motoko_docs")
+    
+    # Find all documentation files
+    doc_files = find_doc_files(DOCS_DIR)
+    print(f"Found {len(doc_files)} documentation files.")
+    
+    docs, embeddings, metadatas, ids = [], [], [], []
+    chunk_id = 0
+    
+    # Process each documentation file
+    for file_path in tqdm(doc_files, desc="Processing documentation files", unit="file"):
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                raw_content = f.read()
+            
+            if not raw_content.strip():
+                continue
+            
+            # Extract frontmatter and content
+            frontmatter, content = extract_frontmatter(raw_content)
+            
+            # Parse headers
+            headers = parse_headers(content)
+            
+            # Get file metadata
+            file_metadata = get_file_metadata(file_path, DOCS_DIR, frontmatter)
+            
+            # Chunk the content
+            chunks = chunk_content(content, headers, file_path, frontmatter)
+            
+            # Process each chunk
+            for chunk in chunks:
+                chunk_text = chunk['content']
+                if len(chunk_text.strip()) < 50:  # Skip very small chunks
+                    continue
+                
+                # Create comprehensive metadata
+                metadata = file_metadata.copy()
+                metadata.update({
+                    'chunk_title': chunk['title'],
+                    'parent_context': chunk['parent_context'],
+                    'section_type': chunk['section_type'],
+                    'chunk_size': len(chunk_text),
+                    'context_headers': ", ".join(chunk['headers']) if chunk['headers'] else ""
+                })
+                
+                # Ensure all metadata values are valid types for ChromaDB
+                for key, value in metadata.items():
+                    if isinstance(value, list):
+                        metadata[key] = ", ".join(str(v) for v in value)
+                    elif not isinstance(value, (str, int, float, bool)) or value is None:
+                        metadata[key] = str(value) if value is not None else ""
+                
+                # Generate embedding
+                embedding = get_embedding(chunk_text)
+                
+                # Store
+                docs.append(chunk_text)
+                embeddings.append(embedding)
+                metadatas.append(metadata)
+                ids.append(f"motoko_docs_{chunk_id}")
+                
+                print(f"Processed chunk {chunk_id}: {chunk['title'][:60]}...")
+                chunk_id += 1
+                
+        except Exception as e:
+            print(f"Error processing {file_path}: {e}")
+            continue
+    
+    # Store in ChromaDB
+    if docs:
+        print(f"Storing {len(docs)} documentation chunks in ChromaDB...")
+        collection.add(
+            documents=docs,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            ids=ids
+        )
+        print("Documentation ingestion completed!")
+    else:
+        print("No documentation chunks to store.")
+
+if __name__ == "__main__":
+    main()

--- a/inspect_chromadb.py
+++ b/inspect_chromadb.py
@@ -2,7 +2,7 @@ import chromadb
 from chromadb.config import Settings
 import os
 
-CHROMA_DIR = os.path.join(os.path.dirname(__file__), "chromadb_data")
+CHROMA_DIR = os.path.join(os.getcwd(), "chromadb_data")
 
 def get_dir_size_mb(path):
     total = 0

--- a/rag/base.py
+++ b/rag/base.py
@@ -1,0 +1,121 @@
+import os
+import chromadb
+from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# ChromaDB setup
+CHROMA_DIR = os.path.join(os.getcwd(), "chromadb_data")
+chroma_client = chromadb.PersistentClient(path=CHROMA_DIR)
+code_collection = chroma_client.get_or_create_collection("motoko_code_samples")
+docs_collection = chroma_client.get_or_create_collection("motoko_docs")
+
+# Embedding function for retrieval
+embedding_fn = SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+
+
+def retrieve_context(query, code_results=5, docs_results=8):
+    """Retrieve context from both code samples and documentation."""
+    query_emb = embedding_fn([query])[0]
+
+    # Retrieve from code samples
+    code_results_data = code_collection.query(
+        query_embeddings=[query_emb], n_results=code_results
+    )
+    code_docs = code_results_data.get("documents", [[]])[0]
+    code_metas = code_results_data.get("metadatas", [[]])[0]
+    code_distances = code_results_data.get("distances", [[]])[0]
+
+    # Retrieve from documentation
+    docs_results_data = docs_collection.query(
+        query_embeddings=[query_emb], n_results=docs_results
+    )
+    doc_docs = docs_results_data.get("documents", [[]])[0]
+    doc_metas = docs_results_data.get("metadatas", [[]])[0]
+    doc_distances = docs_results_data.get("distances", [[]])[0]
+
+    return {
+        "code_docs": code_docs,
+        "code_metas": code_metas,
+        "code_distances": code_distances,
+        "doc_docs": doc_docs,
+        "doc_metas": doc_metas,
+        "doc_distances": doc_distances,
+    }
+
+
+def build_context_prompt(retrieved_data, query, system_message=None):
+    """Build a comprehensive context prompt from retrieved data."""
+    context_parts = []
+
+    # Add documentation context
+    if retrieved_data["doc_docs"]:
+        context_parts.append("=== MOTOKO DOCUMENTATION ===")
+        doc_results = list(
+            zip(
+                retrieved_data["doc_docs"],
+                retrieved_data["doc_metas"],
+                retrieved_data["doc_distances"],
+            )
+        )
+        doc_results.sort(key=lambda x: x[2])  # Sort by distance (lower = more relevant)
+
+        for i, (doc, meta, distance) in enumerate(doc_results[:5]):  # Top 5 docs
+            similarity = 1 - distance if distance <= 1 else 0
+            context_parts.append(
+                f"[DOC {i+1}] {meta.get('chunk_title', 'Untitled')} (Relevance: {similarity:.3f})"
+            )
+            context_parts.append(f"Source: {meta.get('source_file', 'Unknown')}")
+            if meta.get("parent_context"):
+                context_parts.append(f"Context: {meta.get('parent_context')}")
+            context_parts.append(doc)
+            context_parts.append("")
+
+    # Add code examples context
+    if retrieved_data["code_docs"]:
+        context_parts.append("=== MOTOKO CODE EXAMPLES ===")
+        code_results = list(
+            zip(
+                retrieved_data["code_docs"],
+                retrieved_data["code_metas"],
+                retrieved_data["code_distances"],
+            )
+        )
+        code_results.sort(key=lambda x: x[2])  # Sort by distance
+
+        for i, (code, meta, distance) in enumerate(
+            code_results[:3]
+        ):  # Top 3 code examples
+            similarity = 1 - distance if distance <= 1 else 0
+            context_parts.append(
+                f"[CODE {i+1}] {meta.get('filename', 'Unknown')} (Relevance: {similarity:.3f})"
+            )
+            context_parts.append(f"Path: {meta.get('rel_path', 'Unknown')}")
+            context_parts.append(code)
+            context_parts.append("")
+
+    context = "\n".join(context_parts)
+
+    # Use provided system message or default
+    default_system_message = """You are an expert Motoko programmer and teacher. Use the provided documentation and code examples to answer the user's question accurately and comprehensively."""
+
+    system_msg = system_message or default_system_message
+
+    # Create the full prompt
+    prompt = f"""{system_msg}
+
+{context}
+
+User Question: {query}
+
+Instructions:
+- Provide a clear, accurate answer based on the documentation and code examples above
+- Include relevant code snippets when helpful
+- Reference the documentation sources when appropriate
+- If the question can't be fully answered from the provided context, mention what additional information might be needed
+
+Answer:"""
+
+    return prompt

--- a/rag/inference_gemini.py
+++ b/rag/inference_gemini.py
@@ -1,13 +1,13 @@
 import os
-import chromadb
-from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
 from dotenv import load_dotenv
 import requests
 import textwrap
+from base import retrieve_context, build_context_prompt
 
 # Try to import the Gemini SDK
 try:
     import google.generativeai as genai
+
     GEMINI_SDK_AVAILABLE = True
 except ImportError:
     GEMINI_SDK_AVAILABLE = False
@@ -15,14 +15,6 @@ except ImportError:
 # Load environment variables
 load_dotenv()
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
-
-# ChromaDB setup
-CHROMA_DIR = os.path.join(os.getcwd(), "chromadb_data")
-chroma_client = chromadb.PersistentClient(path=CHROMA_DIR)
-collection = chroma_client.get_or_create_collection("motoko_code_samples")
-
-# Embedding function for retrieval
-embedding_fn = SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
 
 # Gemini inference parameters
 GENERATION_CONFIG = {
@@ -33,12 +25,6 @@ GENERATION_CONFIG = {
 }
 MODEL_NAME = "models/gemini-2.5-flash"  # Gemini Flash 2.5
 
-def retrieve_context(query, n_results=10):
-    query_emb = embedding_fn([query])[0]
-    results = collection.query(query_embeddings=[query_emb], n_results=n_results)
-    docs = results.get("documents", [[]])[0]
-    metadatas = results.get("metadatas", [[]])[0]
-    return docs, metadatas
 
 def count_tokens_gemini_sdk(model, prompt):
     # Use the Gemini SDK to count tokens
@@ -47,27 +33,24 @@ def count_tokens_gemini_sdk(model, prompt):
     except Exception:
         return None
 
-def answer_with_gemini_sdk(query, context):
+
+def answer_with_gemini_sdk(query, retrieved_data):
     genai.configure(api_key=GEMINI_API_KEY)
-    model = genai.GenerativeModel(
-        MODEL_NAME,
-        generation_config=GENERATION_CONFIG
-    )
-    prompt = f"Context:\n{context}\n\n Request: {query}\nAnswer:"
+    model = genai.GenerativeModel(MODEL_NAME, generation_config=GENERATION_CONFIG)
+    prompt = build_context_prompt(retrieved_data, query)
     num_tokens = count_tokens_gemini_sdk(model, prompt)
     response = model.generate_content(prompt)
     return response.text, num_tokens
 
-def answer_with_gemini_rest(query, context):
+
+def answer_with_gemini_rest(query, retrieved_data):
     url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent"
     headers = {"Content-Type": "application/json"}
     params = {"key": GEMINI_API_KEY}
-    prompt = f"Context:\n{context}\n\nQuestion: {query}\nAnswer:"
+    prompt = build_context_prompt(retrieved_data, query)
     data = {
-        "contents": [{
-            "parts": [{"text": prompt}]
-        }],
-        "generationConfig": GENERATION_CONFIG
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": GENERATION_CONFIG,
     }
     resp = requests.post(url, headers=headers, params=params, json=data)
     if resp.ok:
@@ -77,25 +60,73 @@ def answer_with_gemini_rest(query, context):
     else:
         return f"Gemini API error: {resp.text}", None
 
+
 def main():
     query = input("Enter your Motoko-related question: ")
-    docs, metadatas = retrieve_context(query)
-    context = "\n---\n".join(docs)
+
+    # Retrieve combined context
+    retrieved_data = retrieve_context(query)
+
     print("\nRetrieved context:")
-    for i, (doc, meta) in enumerate(zip(docs, metadatas)):
-        print(f"[{i+1}] {meta['filename']} ({meta['folders']}):\n{doc[:200]}...\n")
-    print("\n---\n")
+    print(f"Documentation chunks: {len(retrieved_data['doc_docs'])}")
+    print(f"Code examples: {len(retrieved_data['code_docs'])}")
+
+    # Show documentation context
+    if retrieved_data["doc_docs"]:
+        print("\n=== DOCUMENTATION RESULTS ===")
+        doc_results = list(
+            zip(
+                retrieved_data["doc_docs"],
+                retrieved_data["doc_metas"],
+                retrieved_data["doc_distances"],
+            )
+        )
+        doc_results.sort(key=lambda x: x[2])  # Sort by distance
+
+        for i, (doc, meta, distance) in enumerate(doc_results[:3]):  # Show top 3
+            similarity = 1 - distance if distance <= 1 else 0
+            print(
+                f"[DOC {i+1}] {meta.get('chunk_title', 'Untitled')} (Score: {similarity:.3f})"
+            )
+            print(f"Source: {meta.get('source_file', 'Unknown')}")
+            print(f"Content: {doc[:150]}...")
+            print()
+
+    # Show code context
+    if retrieved_data["code_docs"]:
+        print("=== CODE EXAMPLES ===")
+        code_results = list(
+            zip(
+                retrieved_data["code_docs"],
+                retrieved_data["code_metas"],
+                retrieved_data["code_distances"],
+            )
+        )
+        code_results.sort(key=lambda x: x[2])  # Sort by distance
+
+        for i, (code, meta, distance) in enumerate(code_results[:2]):  # Show top 2
+            similarity = 1 - distance if distance <= 1 else 0
+            print(
+                f"[CODE {i+1}] {meta.get('filename', 'Unknown')} (Score: {similarity:.3f})"
+            )
+            print(f"Path: {meta.get('rel_path', 'Unknown')}")
+            print(f"Content: {code[:150]}...")
+            print()
+
+    print("\n" + "=" * 60)
     print(f"Gemini model: {MODEL_NAME}")
-    print(f"Generation config: {GENERATION_CONFIG}")
     print("\nGemini response:")
+
     if GEMINI_SDK_AVAILABLE:
-        answer, num_tokens = answer_with_gemini_sdk(query, context)
+        answer, num_tokens = answer_with_gemini_sdk(query, retrieved_data)
         if num_tokens is not None:
             print(f"[Token count for prompt: {num_tokens}]")
     else:
-        answer, _ = answer_with_gemini_rest(query, context)
+        answer, _ = answer_with_gemini_rest(query, retrieved_data)
         print("[Token count not available: Gemini SDK not installed]")
+
     print(answer)
 
+
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
- Add script to clone docs from [motoko official repo](https://github.com/dfinity/motoko/tree/master/doc/md)

- Add `base.py` in `rag` module to group reusable methods

- Modify `inference_gemini.py` to use methods defined in `base.py`

- Add test script `test_docs_retrieval.py`, ensure documents are ingested before running:
  `python test_docs_retrieval.py "What is actor in motoko"`

- Add motoko docs ingestion pipeline:
    Chunking Strategy:
  
    Primary Chunking (Header-Based):
    - Chunks content by markdown headers (H1-H4)
    - Each section becomes a chunk from one header to the next header of same/higher level
    - Preserves hierarchical context with parent section titles
  
    Size Management:
    - Target chunk size: 2000 characters (400-500 tokens)
    - Minimum chunk size: 50 characters (skips smaller chunks)
    - Large section splitting: Chunks >2000 chars get split further
  
    Fallback Splitting Strategies:
    1. Subsection splitting:
      - Splits on H3-H6 subheadings using regex pattern
      - Maintains section context in titles
    2. Paragraph splitting:
      - Final fallback for content without clear structure
      - Splits on double newlines (\n\n)
      - Max ~1500 characters per paragraph chunk
  
    Context Preservation:
    - Parent context: Breadcrumb trail of parent headers (e.g., "Getting Started > Installation")
    - Section classification: API reference, tutorial, setup, troubleshooting, etc.
    - Surrounding headers: Includes 2 headers before/after current section for context
  
    Metadata Enrichment:
    - Document category based on file path (base_library, fundamentals, examples, etc.)
    - Frontmatter extraction from YAML headers
    - Section type classification based on content patterns