### PR TITLE
Feat: Add api key creation endpoint & validation for MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ GEMINI_API_KEY=your-gemini-key-here
 CLAUDE_API_KEY=your-claude-key-here
 PYTHONPATH=Your-project-path-here
 ICP_CODER_API_KEY=your-icp-coder-api-key-here
+SECRET_KEY=your-secret-key-jwt-here

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ google-generativeai==0.8.5
 uvicorn==0.32.0
 flask==3.1.1
 mcp[cli]
-
+pyjwt
 apscheduler==3.11.0


### PR DESCRIPTION
This PR add endpoint to generate an api key, and modify mcp server to accept that key, note that this is currently interacting through API call only, for later enhancement, when releasing icp-coder to the public can create a user-friendly frontend which help with API key generation, can take inspiration from https://github.com/upstash/context7

Demonstration:

First login
<img width="2317" height="1356" alt="image" src="https://github.com/user-attachments/assets/fd84be89-043f-4ab8-994d-b7f07bcc8205" />

Add bearer token to /api-keys
<img width="2317" height="1356" alt="image" src="https://github.com/user-attachments/assets/389e282f-3f07-444f-8bca-46c6fe4806fd" />

Add the key to mcp config:
<img width="1985" height="666" alt="image" src="https://github.com/user-attachments/assets/95a50728-3e0a-4f35-aadd-72df1e396bab" />
